### PR TITLE
Bugfix: set the read deadline only when the timeout is not zero

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -30,7 +30,9 @@ func (c *Connection) Close() error {
 
 func (c *Connection) Next() (*Tweet, error) {
     var tweet Tweet
-    c.conn.SetReadDeadline(time.Now().Add(c.timeout))
+    if c.timeout != 0 {
+        c.conn.SetReadDeadline(time.Now().Add(c.timeout))
+    }
     if err := c.decoder.Decode(&tweet); err != nil {
         return nil, err
     }


### PR DESCRIPTION
Set the read deadline only when the timeout is not zero. This (with the.zero timeout) fixes the i/o timeout error when trying to read from streams that remain inactive for a long time (this is the case when tracking uncommon hashtags).

The current code always adds a duration to the current time. When the duration is zero (which should actually mean no deadline), the deadline expires immediately. This PR fixes this bug.
